### PR TITLE
Add eb deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2
+jobs:
+  build:
+    working_directory: /app
+    docker:
+      - image: docker:17.05.0-ce-git
+    steps:
+      - run:
+          name: Install Docker Compose
+          command: |
+            curl -L https://github.com/docker/compose/releases/download/1.19.0/docker-compose-`uname -s`-`uname -m` > ~/docker-compose
+            chmod +x ~/docker-compose
+            sudo mv ~/docker-compose /usr/local/bin/docker-compose
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Setup scripts
+          working_directory: /app/scripts
+          command: |
+            ./get-indonesia-tiles.sh
+            ./setup-docker-data-folders.sh
+            ./build.prod.sh
+      - run:
+          name: push repos
+          command: |
+
+      - deploy:
+          name: Deploy to elastic beanstalk
+          command: |
+            chmod +x /app/.circleci/eb_deploy.sh
+            /app/.circleci/eb_deploy.sh

--- a/.circleci/eb_deploy.sh
+++ b/.circleci/eb_deploy.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -xev # halt script on error
+
+# demo and stage branch are set via environment variables in CircleCI
+# DEMO_BRANCH="testing branch"
+# DEV_BRANCH="develop"
+PROD_BRANCH="master"
+
+# DEMO_ENV="visualize-change-demo"
+DEV_ENV="visualize-change-dev"
+PROD_ENV="visualize-change-prod"
+
+echo Running HOT Visualize Change Deployment, current branch is $CIRCLE_BRANCH
+
+# We don't want to deploy Pull Requests only builds on develop and master
+# TODO: commenting this out while develop-branch-travis is a PR
+# if [[ ! -z $CI_PULL_REQUEST ]]
+#     then
+#         echo Not Deploying Build $CIRCLE_BUILD_NUM - Branch is $CIRCLE_BRANCH, Is Pull Request is $CI_PULL_REQUESTS
+#         return
+# fi
+
+# Login to quay to push images
+docker login quay.io -u $QUAY_USER -p $QUAY_TOKEN
+
+# Set Version Number
+VERSION=v.0.0.$CIRCLE_BUILD_NUM-$(echo $CIRCLE_BRANCH | tr -cd '[[:alnum:]]._-')
+
+if [[ $CIRCLE_BRANCH =~ ^($DEV_BRANCH|$PROD_BRANCH)$ ]];
+  then
+    # Install AWS requirements
+    pip install awsebcli==3.10.1
+    printf '1\nn\n' | eb init visualize-change --region us-east-1
+  else
+    echo "$CIRCLE_BRANCH does not match"
+fi
+
+# Set deployment environment
+if [ $CIRCLE_BRANCH == $DEV_BRANCH ]
+  then
+    DEPLOY_ENV=$DEV_ENV
+    DEPLOY_BRANCH=$DEV_BRANCH
+elif [ $CIRCLE_BRANCH == $PROD_BRANCH ]
+  then
+    DEPLOY_ENV=$PROD_ENV
+    DEPLOY_BRANCH=$PROD_BRANCH
+fi
+
+# Deploy develop builds to Staging environment
+docker commit ${docker ps -f "ancestor=hot-mapping-vis-frontend-prod" -ql} quay.io/hotosm/hot-mapping-vis-frontend-$DEPLOY_BRANCH
+docker commit ${docker ps -f "ancestor=hot-mapping-vis-tile-processor" -ql} quay.io/hotosm/hot-mapping-vis-tile-processor-$DEPLOY_BRANCH
+docker commit ${docker ps -f "ancestor=hot-mapping-vis-api-prod" -ql} quay.io/hotosm/hot-mapping-vis-api-$DEPLOY_BRANCH
+docker commit ${docker ps -f "ancestor=hot-mapping-vis-renderer-prod" -ql} quay.io/hotosm/hot-mapping-vis-renderer-$DEPLOY_BRANCH
+docker commit ${docker ps -f "ancestor=hot-mapping-vis-server" -ql} quay.io/hotosm/hot-mapping-vis-server-$DEPLOY_BRANCH
+docker push quay.io/hotosm/hot-mapping-vis-frontend-$DEPLOY_BRANCH
+docker push quay.io/hotosm/hot-mapping-vis-tile-processor-$DEPLOY_BRANCH
+docker push quay.io/hotosm/hot-mapping-vis-api-$DEPLOY_BRANCH
+docker push quay.io/hotosm/hot-mapping-vis-renderer-$DEPLOY_BRANCH
+docker push quay.io/hotosm/hot-mapping-vis-server-$DEPLOY_BRANCH
+
+eb use $DEPLOY_ENV
+echo Deploying $VERSION to $DEPLOY_ENV
+eb deploy -l $VERSION

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ docker/data/
 # env
 .env
 .envrc
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,0 +1,168 @@
+{
+  "AWSEBDockerrunVersion": 2,
+  "volumes": [
+    {
+      "name": "tiles",
+      "host": {
+        "sourcePath": "/var/app/current/docker/data/tiles"
+      }
+    },
+    {
+      "name": "server",
+      "host": {
+        "sourcePath": "/var/app/current/docker/data/capture"
+      }
+    },
+    {
+      "name": "db",
+      "host": {
+        "sourcePath": "/var/app/current/docker/data/db"
+      }
+    },
+    {
+      "name": "initsh",
+      "host": {
+        "sourcePath": "/var/app/current/db/init.sh"
+      }
+    },
+    {
+      "name": "rabbitmq",
+      "host": {
+        "sourcePath": "/var/app/current/docker/data/rabbitmq"
+      }
+    }
+  ],
+  "containerDefinitions": [
+    {
+      "name": "tile-processor",
+      "image": "quay.io/hotosm/hot-mapping-vis-tile-processor:latest",
+      "essential": true,
+      "memory": 256,
+      "environment": [
+        {
+          "name": "GENERATE_UNDERZOOM",
+          "value": "0"
+        }
+      ],
+      "mountPoints": [
+        {
+          "sourceVolume": "tiles",
+          "containerPath": "/data/tiles"
+        }
+      ]
+    },
+    {
+      "name": "server",
+      "image": "quay.io/hotosm/hot-mapping-vis-server:latest",
+      "essential": true,
+      "memory": 256,
+      "portMappings": [
+        {
+          "hostPort": 80,
+          "containerPort": 80
+        },
+        {
+          "hostPort": 8080,
+          "containerPort": 80
+        }
+      ],
+      "links": ["api", "frontend"],
+      "mountPoints": [
+        {
+          "sourceVolume": "server",
+          "containerPath": "/data/capture"
+        }
+      ]
+    },
+    {
+      "name": "frontend",
+      "image": "quay.io/hotosm/hot-mapping-vis-frontend-prod:latest",
+      "essential": true,
+      "memory": 256,
+      "environment": [
+        {
+          "name": "NODE_ENV",
+          "value": "production"
+        }
+      ]
+    },
+    {
+      "name": "renderer",
+      "image": "quay.io/hotosm/hot-mapping-vis-renderer-prod:latest",
+      "essential": true,
+      "memory": 256,
+      "environment": [
+        {
+          "name": "NODE_ENV",
+          "value": "production"
+        },
+        {
+          "name": "RENDER_QUEUE",
+          "value": "render_queue"
+        }
+      ],
+      "links": ["rabbitmq"],
+      "mountPoints": [
+        {
+          "sourceVolume": "server",
+          "containerPath": "/data/capture"
+        }
+      ]
+    },
+    {
+      "name": "api",
+      "image": "quay.io/hotosm/hot-mapping-vis-api-prod:latest",
+      "essential": true,
+      "memory": 256,
+      "environment": [
+        {
+          "name": "NODE_ENV",
+          "value": "production"
+        },
+        {
+          "name": "RENDER_QUEUE",
+          "value": "render_queue"
+        },
+        {
+          "name": "MAILGUN_FROM",
+          "value": "visualize@hotosmmail.org"
+        }
+      ],
+      "links": ["db", "rabbitmq"],
+      "mountPoints": [
+        {
+          "sourceVolume": "tiles",
+          "containerPath": "/data/tiles"
+        }
+      ]
+    },
+    {
+      "name": "db",
+      "image": "postgres",
+      "essential": true,
+      "memory": 256,
+      "mountPoints": [
+        {
+          "sourceVolume": "db",
+          "containerPath": "/var/lib/postgresql/data"
+        },
+        {
+          "sourceVolume": "initsh",
+          "containerPath": "/docker-entrypoint-initdb.d/init.sh"
+        }
+      ]
+    },
+    {
+      "name": "rabbitmq",
+      "image": "rabbitmq:3",
+      "essential": true,
+      "memory": 256,
+      "mountPoints": [
+        {
+          "sourceVolume": "rabbitmq",
+          "containerPath": "/var/lib/rabbitmq"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This allows us to perform automatic deployments to elastic beanstalk. 

Note I am pushing to a new `develop` branch. This follows a [git workflow model](http://nvie.com/posts/a-successful-git-branching-model/) used in TM3 that I find effective. This also won't disrupt anything production while I am testing. 