### PR TITLE
Enable Elastic Beanstalk deployment

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,10 @@
+from ubuntu:latest
+
+RUN apt update && \
+    apt install -y python-dev python-pip apt-transport-https \
+      ca-certificates curl software-properties-common && \
+      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) stable" && \
+    apt update && apt install -y docker-ce && \
+    pip install docker-compose awscli==1.11.76

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
       - deploy:
           name: Deploy to elastic beanstalk
           command: |
-            docker-compose -f -f /app/docker/docker-compose.prod.yml up
+            docker-compose -f /app/docker/docker-compose.prod.yml up
             docker login quay.io -u $QUAY_USER -p $QUAY_TOKEN
             chmod +x /app/.circleci/eb_deploy.sh
             /app/.circleci/eb_deploy.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,18 +3,18 @@ jobs:
   build:
     working_directory: /app
     docker:
-      - image: docker:stable-git
+      - image: quay.io/hotosm/visualize-change-baseimage:latest
     steps:
       - checkout
-      - run:
-          name: Install dependencies
-          command: |
-            apk update && apk add --no-cache \
-              py-pip=9.0.1-r1 \
-              curl curl-dev bash
-            pip install \
-              awscli==1.11.76 \
-              docker-compose
+      # - run:
+      #     name: Install dependencies
+      #     command: |
+      #       apk update && apk add --no-cache \
+      #         py-pip=9.0.1-r1 \
+      #         curl curl-dev bash
+      #       pip install \
+      #         awscli==1.11.76 \
+      #         docker-compose
       - setup_remote_docker
       - restore_cache:
           keys:
@@ -35,10 +35,11 @@ jobs:
       - save_cache:
           paths:
             - /app/docker/data/tiles/
-          key: tiles-cache-{{ checksum "tiles.mbtiles" }}
+          key: tiles-cache-{{ checksum "/app/docker/data/tiles/tiles.mbtiles" }}
       - deploy:
           name: Deploy to elastic beanstalk
           command: |
+            docker-compose -f -f /app/docker/docker-compose.prod.yml up
             docker login quay.io -u $QUAY_USER -p $QUAY_TOKEN
             chmod +x /app/.circleci/eb_deploy.sh
             /app/.circleci/eb_deploy.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2
+jobs:
+  build:
+    working_directory: /app
+    docker:
+      - image: docker:17.05.0-ce-git
+    steps:
+      - run:
+          name: Install Docker Compose
+          command: |
+            curl -L https://github.com/docker/compose/releases/download/1.19.0/docker-compose-`uname -s`-`uname -m` > ~/docker-compose
+            chmod +x ~/docker-compose
+            sudo mv ~/docker-compose /usr/local/bin/docker-compose
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Setup scripts
+          working_directory: /app/scripts
+          command: |
+            ./get-indonesia-tiles.sh
+            ./setup-docker-data-folders.sh
+            ./build.prod.sh
+      - run:
+          name: push repos
+          command: |
+
+      - deploy:
+          name: Deploy to elastic beanstalk
+          command: |
+            chmod +x /app/.circleci/eb_deploy.sh
+            /app/.circleci/eb_deploy.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - restore_cache:
-          keys:
-            tiles-cache-{{ checksum "/app/docker/data/tiles/tiles.mbtiles" }}
-            tiles-cache-
       - run:
           name: Setup scripts
           working_directory: /app/scripts
@@ -24,10 +20,6 @@ jobs:
               mv /app/docker/data/tiles/indonesia.mbtiles /app/docker/data/tiles/tiles.mbtiles
             fi
             mkdir -p /app/docker/data/capture /app/docker/data/db /app/docker/data/rabbitmq data/tiles > /dev/null
-      - save_cache:
-          paths:
-            - /app/docker/data/tiles/
-          key: tiles-cache-{{ checksum "/app/docker/data/tiles/tiles.mbtiles" }}
       - deploy:
           name: Deploy to elastic beanstalk
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
               gunzip /app/docker/data/tiles/indonesia.mbtiles.gz
               mv /app/docker/data/tiles/indonesia.mbtiles /app/docker/data/tiles/tiles.mbtiles
             fi
-            mkdir -p /app/docker/data/capture /app/docker/data/db /app/docker/data/rabbitmq data/tiles > /dev/null
+            mkdir -p /app/docker/data/capture /app/docker/data/db /app/docker/data/rabbitmq /app/docker/data/tiles > /dev/null
       - deploy:
           name: Deploy to elastic beanstalk
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - setup_remote_docker
       - restore_cache:
           keys:
-            tiles-cache-{{ checksum "tiles.mbtiles" }}
+            tiles-cache-{{ checksum "/app/docker/data/tiles/tiles.mbtiles" }}
             tiles-cache-
       - run:
           name: Setup scripts
@@ -30,6 +30,7 @@ jobs:
             if [ ! -f /app/docker/data/tiles/indonesia.mbtiles.gz ]; then
               curl -o /app/docker/data/tiles/indonesia.mbtiles.gz https://s3.amazonaws.com/mapbox/osm-qa-tiles-production/latest.country/indonesia.mbtiles.gz
               gunzip /app/docker/data/tiles/indonesia.mbtiles.gz
+              mv /app/docker/data/tiles/indonesia.mbtiles /app/docker/data/tiles/tiles.mbtiles
             fi
             mkdir -p /app/docker/data/capture /app/docker/data/db /app/docker/data/rabbitmq data/tiles > /dev/null
       - save_cache:
@@ -40,7 +41,6 @@ jobs:
           name: Deploy to elastic beanstalk
           command: |
             docker-compose -f /app/docker/docker-compose.prod.yml up -d
-            docker login quay.io -u $QUAY_USER -p $QUAY_TOKEN
             chmod +x /app/.circleci/eb_deploy.sh
             /app/.circleci/eb_deploy.sh
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,26 +3,47 @@ jobs:
   build:
     working_directory: /app
     docker:
-      - image: docker:17.05.0-ce-git
+      - image: docker:stable-git
     steps:
-      - run:
-          name: Install Docker Compose
-          command: |
-            apk update && apk add curl curl-dev bash
-            curl -L https://github.com/docker/compose/releases/download/1.19.0/docker-compose-`uname -s`-`uname -m` > ~/docker-compose
-            chmod +x ~/docker-compose
-            sudo mv ~/docker-compose /usr/local/bin/docker-compose
       - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            apk update && apk add --no-cache \
+              py-pip=9.0.1-r1 \
+              curl curl-dev bash
+            pip install \
+              awscli==1.11.76 \
+              docker-compose
       - setup_remote_docker
+      - restore_cache:
+          keys:
+            tiles-cache-{{ checksum "tiles.mbtiles" }}
+            tiles-cache-
       - run:
           name: Setup scripts
           working_directory: /app/scripts
           command: |
-            ./get-indonesia-tiles.sh
-            ./setup-docker-data-folders.sh
-            ./build.prod.sh
+            set -x
+            docker-compose -f /app/docker/docker-compose.prod.yml build
+            mkdir -p /app/docker/data/tiles
+            if [ ! -f /app/docker/data/tiles/indonesia.mbtiles.gz ]; then
+              curl -o /app/docker/data/tiles/indonesia.mbtiles.gz https://s3.amazonaws.com/mapbox/osm-qa-tiles-production/latest.country/indonesia.mbtiles.gz
+              gunzip /app/docker/data/tiles/indonesia.mbtiles.gz
+            fi
+            mkdir -p /app/docker/data/capture /app/docker/data/db /app/docker/data/rabbitmq data/tiles > /dev/null
+      - save_cache:
+          paths:
+            - /app/docker/data/tiles/
+          key: tiles-cache-{{ checksum "tiles.mbtiles" }}
       - deploy:
           name: Deploy to elastic beanstalk
           command: |
+            docker login quay.io -u $QUAY_USER -p $QUAY_TOKEN
             chmod +x /app/.circleci/eb_deploy.sh
             /app/.circleci/eb_deploy.sh
+      - run:
+          name: Save Docker image layer cache
+          command: |
+            mkdir -p /caches
+            docker save -o /caches/app.tar app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,6 @@ jobs:
             ./get-indonesia-tiles.sh
             ./setup-docker-data-folders.sh
             ./build.prod.sh
-      - run:
-          name: push repos
-          command: |
-
       - deploy:
           name: Deploy to elastic beanstalk
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,15 +6,6 @@ jobs:
       - image: quay.io/hotosm/visualize-change-baseimage:latest
     steps:
       - checkout
-      # - run:
-      #     name: Install dependencies
-      #     command: |
-      #       apk update && apk add --no-cache \
-      #         py-pip=9.0.1-r1 \
-      #         curl curl-dev bash
-      #       pip install \
-      #         awscli==1.11.76 \
-      #         docker-compose
       - setup_remote_docker
       - restore_cache:
           keys:
@@ -40,11 +31,7 @@ jobs:
       - deploy:
           name: Deploy to elastic beanstalk
           command: |
+            docker login quay.io -u $QUAY_USER -p $QUAY_TOKEN
             docker-compose -f /app/docker/docker-compose.prod.yml up -d
             chmod +x /app/.circleci/eb_deploy.sh
             /app/.circleci/eb_deploy.sh
-      - run:
-          name: Save Docker image layer cache
-          command: |
-            mkdir -p /caches
-            docker save -o /caches/app.tar app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
       - deploy:
           name: Deploy to elastic beanstalk
           command: |
-            docker-compose -d -f /app/docker/docker-compose.prod.yml up
+            docker-compose -f /app/docker/docker-compose.prod.yml up -d
             docker login quay.io -u $QUAY_USER -p $QUAY_TOKEN
             chmod +x /app/.circleci/eb_deploy.sh
             /app/.circleci/eb_deploy.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       - run:
           name: Install Docker Compose
           command: |
+            apk update && apk add curl curl-dev bash
             curl -L https://github.com/docker/compose/releases/download/1.19.0/docker-compose-`uname -s`-`uname -m` > ~/docker-compose
             chmod +x ~/docker-compose
             sudo mv ~/docker-compose /usr/local/bin/docker-compose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
       - deploy:
           name: Deploy to elastic beanstalk
           command: |
-            docker-compose -f /app/docker/docker-compose.prod.yml up
+            docker-compose -d -f /app/docker/docker-compose.prod.yml up
             docker login quay.io -u $QUAY_USER -p $QUAY_TOKEN
             chmod +x /app/.circleci/eb_deploy.sh
             /app/.circleci/eb_deploy.sh

--- a/.circleci/eb_deploy.sh
+++ b/.circleci/eb_deploy.sh
@@ -45,7 +45,7 @@ elif [ $CIRCLE_BRANCH == $PROD_BRANCH ]
 fi
 
 # Deploy develop builds to Staging environment
-docker login quay.io -u $QUAY_USER -p $QUAY_TOKEN
+echo $QUAY_TOKEN | docker login quay.io -u $QUAY_USER --password-stdin
 
 docker commit $(docker ps -f "ancestor=hot-mapping-vis-frontend-prod" -ql) quay.io/hotosm/hot-mapping-vis-frontend-$DEPLOY_BRANCH
 docker commit $(docker ps -f "ancestor=hot-mapping-vis-tile-processor" -ql) quay.io/hotosm/hot-mapping-vis-tile-processor-$DEPLOY_BRANCH

--- a/.circleci/eb_deploy.sh
+++ b/.circleci/eb_deploy.sh
@@ -45,6 +45,8 @@ elif [ $CIRCLE_BRANCH == $PROD_BRANCH ]
 fi
 
 # Deploy develop builds to Staging environment
+docker login quay.io -u $QUAY_USER -p $QUAY_TOKEN
+
 docker commit $(docker ps -f "ancestor=hot-mapping-vis-frontend-prod" -ql) quay.io/hotosm/hot-mapping-vis-frontend-$DEPLOY_BRANCH
 docker commit $(docker ps -f "ancestor=hot-mapping-vis-tile-processor" -ql) quay.io/hotosm/hot-mapping-vis-tile-processor-$DEPLOY_BRANCH
 docker commit $(docker ps -f "ancestor=hot-mapping-vis-api-prod" -ql) quay.io/hotosm/hot-mapping-vis-api-$DEPLOY_BRANCH

--- a/.circleci/eb_deploy.sh
+++ b/.circleci/eb_deploy.sh
@@ -7,7 +7,7 @@ DEV_BRANCH="develop"
 PROD_BRANCH="master"
 
 # DEMO_ENV="visualize-change-demo"
-DEV_ENV="visualize-change-dev-2"
+DEV_ENV="VisualizeChange-env-1"
 PROD_ENV="visualize-change-prod"
 
 echo Running HOT Visualize Change Deployment, current branch is $CIRCLE_BRANCH

--- a/.circleci/eb_deploy.sh
+++ b/.circleci/eb_deploy.sh
@@ -44,8 +44,6 @@ elif [ $CIRCLE_BRANCH == $PROD_BRANCH ]
     DEPLOY_BRANCH=$PROD_BRANCH
 fi
 
-# Deploy develop builds to Staging environment
-echo $QUAY_TOKEN | docker login quay.io -u $QUAY_USER --password-stdin
 
 docker commit $(docker ps -f "ancestor=hot-mapping-vis-frontend-prod" -ql) quay.io/hotosm/hot-mapping-vis-frontend-$DEPLOY_BRANCH
 docker commit $(docker ps -f "ancestor=hot-mapping-vis-tile-processor" -ql) quay.io/hotosm/hot-mapping-vis-tile-processor-$DEPLOY_BRANCH

--- a/.circleci/eb_deploy.sh
+++ b/.circleci/eb_deploy.sh
@@ -3,8 +3,8 @@ set -xev # halt script on error
 
 # demo and stage branch are set via environment variables in CircleCI
 # DEMO_BRANCH="testing branch"
-DEV_BRANCH="demo"
-PROD_BRANCH="develop"
+DEV_BRANCH="develop"
+PROD_BRANCH="master"
 
 # DEMO_ENV="visualize-change-demo"
 # DEV_ENV="visualize-change-dev" Set in CircleCI

--- a/.circleci/eb_deploy.sh
+++ b/.circleci/eb_deploy.sh
@@ -42,8 +42,12 @@ elif [ $CIRCLE_BRANCH == $PROD_BRANCH ]
   then
     DEPLOY_ENV=$PROD_ENV
     DEPLOY_BRANCH=$PROD_BRANCH
+else
+  echo "No suitable Deployment branch for $CIRCLE_BRANCH. Ignore this if testing a pull request. Exiting..."
+  exit 0
 fi
 
+echo "Deploying to $DEPLOY_BRANCH"
 
 docker commit $(docker ps -f "ancestor=hot-mapping-vis-frontend-prod" -ql) quay.io/hotosm/hot-mapping-vis-frontend-$DEPLOY_BRANCH
 docker commit $(docker ps -f "ancestor=hot-mapping-vis-tile-processor" -ql) quay.io/hotosm/hot-mapping-vis-tile-processor-$DEPLOY_BRANCH

--- a/.circleci/eb_deploy.sh
+++ b/.circleci/eb_deploy.sh
@@ -7,7 +7,7 @@ DEV_BRANCH="develop"
 PROD_BRANCH="master"
 
 # DEMO_ENV="visualize-change-demo"
-DEV_ENV="visualize-change-dev"
+# DEV_ENV="visualize-change-dev" Set in CircleCI
 PROD_ENV="visualize-change-prod"
 
 echo Running HOT Visualize Change Deployment, current branch is $CIRCLE_BRANCH

--- a/.circleci/eb_deploy.sh
+++ b/.circleci/eb_deploy.sh
@@ -3,12 +3,12 @@ set -xev # halt script on error
 
 # demo and stage branch are set via environment variables in CircleCI
 # DEMO_BRANCH="testing branch"
-DEV_BRANCH="develop"
-PROD_BRANCH="master"
+DEV_BRANCH="demo"
+PROD_BRANCH="develop"
 
 # DEMO_ENV="visualize-change-demo"
 # DEV_ENV="visualize-change-dev" Set in CircleCI
-PROD_ENV="visualize-change-prod"
+PROD_ENV="visualize-change-dev"
 
 echo Running HOT Visualize Change Deployment, current branch is $CIRCLE_BRANCH
 

--- a/.circleci/eb_deploy.sh
+++ b/.circleci/eb_deploy.sh
@@ -58,4 +58,4 @@ docker push quay.io/hotosm/hot-mapping-vis-server-$DEPLOY_BRANCH
 
 eb use $DEPLOY_ENV
 echo Deploying $VERSION to $DEPLOY_ENV
-eb deploy -l $VERSION
+eb deploy -l $VERSION --timeout 20

--- a/.circleci/eb_deploy.sh
+++ b/.circleci/eb_deploy.sh
@@ -42,12 +42,8 @@ elif [ $CIRCLE_BRANCH == $PROD_BRANCH ]
   then
     DEPLOY_ENV=$PROD_ENV
     DEPLOY_BRANCH=$PROD_BRANCH
-else
-  echo "No suitable Deployment branch for $CIRCLE_BRANCH. Ignore this if testing a pull request. Exiting..."
-  exit 0
 fi
 
-echo "Deploying to $DEPLOY_BRANCH"
 
 docker commit $(docker ps -f "ancestor=hot-mapping-vis-frontend-prod" -ql) quay.io/hotosm/hot-mapping-vis-frontend-$DEPLOY_BRANCH
 docker commit $(docker ps -f "ancestor=hot-mapping-vis-tile-processor" -ql) quay.io/hotosm/hot-mapping-vis-tile-processor-$DEPLOY_BRANCH

--- a/.circleci/eb_deploy.sh
+++ b/.circleci/eb_deploy.sh
@@ -3,7 +3,7 @@ set -xev # halt script on error
 
 # demo and stage branch are set via environment variables in CircleCI
 # DEMO_BRANCH="testing branch"
-# DEV_BRANCH="develop"
+DEV_BRANCH="develop"
 PROD_BRANCH="master"
 
 # DEMO_ENV="visualize-change-demo"
@@ -20,8 +20,6 @@ echo Running HOT Visualize Change Deployment, current branch is $CIRCLE_BRANCH
 #         return
 # fi
 
-# Login to quay to push images
-docker login quay.io -u $QUAY_USER -p $QUAY_TOKEN
 
 # Set Version Number
 VERSION=v.0.0.$CIRCLE_BUILD_NUM-$(echo $CIRCLE_BRANCH | tr -cd '[[:alnum:]]._-')
@@ -47,11 +45,11 @@ elif [ $CIRCLE_BRANCH == $PROD_BRANCH ]
 fi
 
 # Deploy develop builds to Staging environment
-docker commit ${docker ps -f "ancestor=hot-mapping-vis-frontend-prod" -ql} quay.io/hotosm/hot-mapping-vis-frontend-$DEPLOY_BRANCH
-docker commit ${docker ps -f "ancestor=hot-mapping-vis-tile-processor" -ql} quay.io/hotosm/hot-mapping-vis-tile-processor-$DEPLOY_BRANCH
-docker commit ${docker ps -f "ancestor=hot-mapping-vis-api-prod" -ql} quay.io/hotosm/hot-mapping-vis-api-$DEPLOY_BRANCH
-docker commit ${docker ps -f "ancestor=hot-mapping-vis-renderer-prod" -ql} quay.io/hotosm/hot-mapping-vis-renderer-$DEPLOY_BRANCH
-docker commit ${docker ps -f "ancestor=hot-mapping-vis-server" -ql} quay.io/hotosm/hot-mapping-vis-server-$DEPLOY_BRANCH
+docker commit $(docker ps -f "ancestor=hot-mapping-vis-frontend-prod" -ql) quay.io/hotosm/hot-mapping-vis-frontend-$DEPLOY_BRANCH
+docker commit $(docker ps -f "ancestor=hot-mapping-vis-tile-processor" -ql) quay.io/hotosm/hot-mapping-vis-tile-processor-$DEPLOY_BRANCH
+docker commit $(docker ps -f "ancestor=hot-mapping-vis-api-prod" -ql) quay.io/hotosm/hot-mapping-vis-api-$DEPLOY_BRANCH
+docker commit $(docker ps -f "ancestor=hot-mapping-vis-renderer-prod" -ql) quay.io/hotosm/hot-mapping-vis-renderer-$DEPLOY_BRANCH
+docker commit $(docker ps -f "ancestor=hot-mapping-vis-server" -ql) quay.io/hotosm/hot-mapping-vis-server-$DEPLOY_BRANCH
 docker push quay.io/hotosm/hot-mapping-vis-frontend-$DEPLOY_BRANCH
 docker push quay.io/hotosm/hot-mapping-vis-tile-processor-$DEPLOY_BRANCH
 docker push quay.io/hotosm/hot-mapping-vis-api-$DEPLOY_BRANCH

--- a/.circleci/eb_deploy.sh
+++ b/.circleci/eb_deploy.sh
@@ -7,7 +7,7 @@ DEV_BRANCH="develop"
 PROD_BRANCH="master"
 
 # DEMO_ENV="visualize-change-demo"
-DEV_ENV="visualize-change-dev"
+DEV_ENV="visualize-change-dev-2"
 PROD_ENV="visualize-change-prod"
 
 echo Running HOT Visualize Change Deployment, current branch is $CIRCLE_BRANCH

--- a/.circleci/eb_deploy.sh
+++ b/.circleci/eb_deploy.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -xev # halt script on error
+
+# demo and stage branch are set via environment variables in CircleCI
+# DEMO_BRANCH="testing branch"
+# DEV_BRANCH="develop"
+PROD_BRANCH="master"
+
+# DEMO_ENV="visualize-change-demo"
+DEV_ENV="visualize-change-dev"
+PROD_ENV="visualize-change-prod"
+
+echo Running HOT Visualize Change Deployment, current branch is $CIRCLE_BRANCH
+
+# We don't want to deploy Pull Requests only builds on develop and master
+# TODO: commenting this out while develop-branch-travis is a PR
+# if [[ ! -z $CI_PULL_REQUEST ]]
+#     then
+#         echo Not Deploying Build $CIRCLE_BUILD_NUM - Branch is $CIRCLE_BRANCH, Is Pull Request is $CI_PULL_REQUESTS
+#         return
+# fi
+
+# Login to quay to push images
+docker login quay.io -u $QUAY_USER -p $QUAY_TOKEN
+
+# Set Version Number
+VERSION=v.0.0.$CIRCLE_BUILD_NUM-$(echo $CIRCLE_BRANCH | tr -cd '[[:alnum:]]._-')
+
+if [[ $CIRCLE_BRANCH =~ ^($DEV_BRANCH|$PROD_BRANCH)$ ]];
+  then
+    # Install AWS requirements
+    pip install awsebcli==3.10.1
+    printf '1\nn\n' | eb init visualize-change --region us-east-1
+  else
+    echo "$CIRCLE_BRANCH does not match"
+fi
+
+# Set deployment environment
+if [ $CIRCLE_BRANCH == $DEV_BRANCH ]
+  then
+    DEPLOY_ENV=$DEV_ENV
+    DEPLOY_BRANCH=$DEV_BRANCH
+elif [ $CIRCLE_BRANCH == $PROD_BRANCH ]
+  then
+    DEPLOY_ENV=$PROD_ENV
+    DEPLOY_BRANCH=$PROD_BRANCH
+fi
+
+# Deploy develop builds to Staging environment
+docker commit ${docker ps -f "ancestor=hot-mapping-vis-frontend-prod" -ql} quay.io/hotosm/hot-mapping-vis-frontend-$DEPLOY_BRANCH
+docker commit ${docker ps -f "ancestor=hot-mapping-vis-tile-processor" -ql} quay.io/hotosm/hot-mapping-vis-tile-processor-$DEPLOY_BRANCH
+docker commit ${docker ps -f "ancestor=hot-mapping-vis-api-prod" -ql} quay.io/hotosm/hot-mapping-vis-api-$DEPLOY_BRANCH
+docker commit ${docker ps -f "ancestor=hot-mapping-vis-renderer-prod" -ql} quay.io/hotosm/hot-mapping-vis-renderer-$DEPLOY_BRANCH
+docker commit ${docker ps -f "ancestor=hot-mapping-vis-server" -ql} quay.io/hotosm/hot-mapping-vis-server-$DEPLOY_BRANCH
+docker push quay.io/hotosm/hot-mapping-vis-frontend-$DEPLOY_BRANCH
+docker push quay.io/hotosm/hot-mapping-vis-tile-processor-$DEPLOY_BRANCH
+docker push quay.io/hotosm/hot-mapping-vis-api-$DEPLOY_BRANCH
+docker push quay.io/hotosm/hot-mapping-vis-renderer-$DEPLOY_BRANCH
+docker push quay.io/hotosm/hot-mapping-vis-server-$DEPLOY_BRANCH
+
+eb use $DEPLOY_ENV
+echo Deploying $VERSION to $DEPLOY_ENV
+eb deploy -l $VERSION

--- a/.circleci/eb_deploy.sh
+++ b/.circleci/eb_deploy.sh
@@ -7,7 +7,7 @@ DEV_BRANCH="develop"
 PROD_BRANCH="master"
 
 # DEMO_ENV="visualize-change-demo"
-DEV_ENV="VisualizeChange-env-1"
+DEV_ENV="visualize-change-dev"
 PROD_ENV="visualize-change-prod"
 
 echo Running HOT Visualize Change Deployment, current branch is $CIRCLE_BRANCH

--- a/.circleci/eb_deploy.sh
+++ b/.circleci/eb_deploy.sh
@@ -58,4 +58,4 @@ docker push quay.io/hotosm/hot-mapping-vis-server-$DEPLOY_BRANCH
 
 eb use $DEPLOY_ENV
 echo Deploying $VERSION to $DEPLOY_ENV
-eb deploy -l $VERSION --timeout 20
+eb deploy -l $VERSION --timeout 30

--- a/.ebextensions/01-increase-timeout.config
+++ b/.ebextensions/01-increase-timeout.config
@@ -1,0 +1,4 @@
+option_settings:
+  - namespace: aws:elasticbeanstalk:command
+    option_name: Timeout
+    value: 3600

--- a/.ebextensions/setup.config
+++ b/.ebextensions/setup.config
@@ -4,4 +4,20 @@ container_commands:
   00_create_data_dirs:
     command: "mkdir -p /efs/data/capture /efs/data/db /efs/data/rabbitmq /efs/data/tiles > /dev/null"
   01_get_earth_tiles:
-    command: "scripts/eb-get-earth-tiles.sh"
+    command: "/tmp/eb-get-earth-tiles.sh"
+
+files:
+  "/tmp/eb-get-earth-tiles.sh":
+      mode: "000755"
+      content : |
+        #!/bin/bash
+        cd /efs/data/tiles || exit 1
+        if [ ! -f tiles.mbtiles ]; then
+          echo "No tiles found, downloading..."
+          rm latest.planet.mbtiles.gz
+          wget https://s3.amazonaws.com/mapbox/osm-qa-tiles-production/latest.planet.mbtiles.gz
+          gunzip latest.planet.mbtiles.gz
+          mv latest.planet.mbtiles tiles.mbtiles
+        else
+          echo "Tiles already exist, skipping download step..."
+        fi

--- a/.ebextensions/setup.config
+++ b/.ebextensions/setup.config
@@ -2,6 +2,6 @@
 
 container_commands:
   00_get_earth_tiles:
-    command: "scripts/get-earth-tiles.sh"
+    command: "scripts/eb-get-earth-tiles.sh"
   01_create_data_dirs:
     command: "mkdir -p /efs/data/capture /efs/data/db /efs/data/rabbitmq /efs/data/tiles > /dev/null"

--- a/.ebextensions/setup.config
+++ b/.ebextensions/setup.config
@@ -3,3 +3,5 @@
 container_commands:
   00_get_earth_tiles:
     command: "scripts/get-earth-tiles.sh"
+  01_create_data_dirs:
+    command: "scripts/setup-docker-data-folders.sh"

--- a/.ebextensions/setup.config
+++ b/.ebextensions/setup.config
@@ -4,4 +4,4 @@ container_commands:
   00_get_earth_tiles:
     command: "scripts/get-earth-tiles.sh"
   01_create_data_dirs:
-    command: "scripts/setup-docker-data-folders.sh"
+    command: "mkdir -p /efs/data/capture /efs/data/db /efs/data/rabbitmq /efs/data/tiles > /dev/null"

--- a/.ebextensions/setup.config
+++ b/.ebextensions/setup.config
@@ -1,7 +1,7 @@
 #Download mbtiles
 
 container_commands:
-  00_get_earth_tiles:
-    command: "scripts/eb-get-earth-tiles.sh"
-  01_create_data_dirs:
+  00_create_data_dirs:
     command: "mkdir -p /efs/data/capture /efs/data/db /efs/data/rabbitmq /efs/data/tiles > /dev/null"
+  01_get_earth_tiles:
+    command: "scripts/eb-get-earth-tiles.sh"

--- a/.ebextensions/storage-efs-createfilesystem.config
+++ b/.ebextensions/storage-efs-createfilesystem.config
@@ -1,0 +1,112 @@
+###################################################################################################
+#### Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file creates an Amazon EFS file system with mount targets in two subnets,
+#### and a security group that allows traffic from the default AWS Elastic Beanstalk instance
+#### security group. Each mount target corresponds to a single Availability Zone (AZ). Depending on
+#### the region, the number of available AZs will vary. You can add mount target resources and the
+#### corresponding subnet option for use in more than two AZs.
+####
+#### EFS requires a VPC. You can use the default VPC or create a custom VPC to use. If you
+#### use a custom VPC, configure it to allow DNS resolution and DNS host names. For more
+#### information, see this topic in the Elastic Beanstalk Developer Guide:
+####    http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/vpc.html
+####
+#### Specify your VPC ID and subnet IDs in the "option_settings" section below. In a custom VPC,
+#### use the VPC ID and subnet IDs that you chose for the Amazon EC2 instances running your
+#### application. When you create a new environment, you can specify VPC settings in a
+#### configuration file with the options in the aws:ec2:vpc namespace. See
+#### vpc-custom-loadbalanced.config in the environment_configuration folder for an example.
+####
+#### To use this configuration file in your default VPC, you must have a mount target for each
+#### default subnet to ensure that all instances can connect to the file system. Use the VPC
+#### management console (https://console.aws.amazon.com/vpc) to determine the number of available
+#### AZs and the default subnet for each. Add a subnet option and mount target resource for
+#### each additional AZ.
+####
+#### EFS supports two performance modes for file systems, "generalPurpose" and "maxIO". Change the
+#### "PerformanceMode" value under "FileSystem" to "maxIO" for increased throughput and IOPS
+#### at the expense of slightly increased latency.
+####
+#### EFS supports encrypted file systems. To create an EFS encrypted file system, change the
+#### "Encrypted" property value to "true". If you keep the "KMSKeyId" property commented out,
+#### EFS uses a default KMS key. Alternatively, you can uncomment "KMSKeyId" (remove the initial "#")
+#### and set its value to a valid ARN of a KMS key.
+#### For information about creating and managing keys, see the AWS Key Management Service
+#### Developer Guide:
+####    http://docs.aws.amazon.com/kms/latest/developerguide
+####
+#### To avoid creating the file system more than once, add this configuration file in a deployment
+#### without any other configuration changes. After the environment update completes and the file
+#### system is ready, use storage-efs-mountfilesystem.config to mount the file system on each
+#### instance. Any errors caused by other configuration files added in the same deployment will
+#### cause the deployment to fail and the file system to be terminated.
+####
+#### Back up the contents of your file system to avoid data loss when your environment is
+#### terminated. The file system will also be terminated if this configuration file is removed or
+#### if you change the performance mode setting.
+###################################################################################################
+
+option_settings:
+  aws:elasticbeanstalk:customoption:
+    VPCId: "vpc-b823efc1"
+## Subnet Options
+    SubnetA: "subnet-adf138f7"
+    SubnetB: "subnet-fe2f129b"
+
+Resources:
+  FileSystem:
+    Type: AWS::EFS::FileSystem
+    Properties:
+      FileSystemTags:
+      - Key: Name
+        Value: "EB-EFS-FileSystem"
+      PerformanceMode: "generalPurpose"
+      Encrypted: "false"
+#      KmsKeyId: "KMS-key-ARN"
+
+## Mount Target Resources
+  MountTargetA:
+    Type: AWS::EFS::MountTarget
+    Properties:
+      FileSystemId: {Ref: FileSystem}
+      SecurityGroups:
+      - {Ref: MountTargetSecurityGroup}
+      SubnetId:
+        Fn::GetOptionSetting: {OptionName: SubnetA}
+  MountTargetB:
+    Type: AWS::EFS::MountTarget
+    Properties:
+      FileSystemId: {Ref: FileSystem}
+      SecurityGroups:
+      - {Ref: MountTargetSecurityGroup}
+      SubnetId:
+        Fn::GetOptionSetting: {OptionName: SubnetB}
+
+##############################################
+#### Do not modify values below this line ####
+##############################################
+
+  MountTargetSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for mount target
+      SecurityGroupIngress:
+      - FromPort: '2049'
+        IpProtocol: tcp
+        SourceSecurityGroupId:
+          Fn::GetAtt: [AWSEBSecurityGroup, GroupId]
+        ToPort: '2049'
+      VpcId:
+        Fn::GetOptionSetting: {OptionName: VPCId}

--- a/.ebextensions/storage-efs-mountfilesystem.config
+++ b/.ebextensions/storage-efs-mountfilesystem.config
@@ -52,6 +52,8 @@ files:
       content : |
         #!/bin/bash
 
+        sleep 1m
+
         EFS_REGION=$(/opt/elasticbeanstalk/bin/get-config environment -k REGION)
         EFS_MOUNT_DIR=$(/opt/elasticbeanstalk/bin/get-config environment -k MOUNT_DIRECTORY)
         EFS_FILE_SYSTEM_ID=$(/opt/elasticbeanstalk/bin/get-config environment -k FILE_SYSTEM_ID)
@@ -103,4 +105,3 @@ files:
         fi
 
         echo 'EFS mount complete.'
-

--- a/.ebextensions/storage-efs-mountfilesystem.config
+++ b/.ebextensions/storage-efs-mountfilesystem.config
@@ -1,0 +1,106 @@
+###################################################################################################
+#### Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file mounts an Amazon EFS file system to a directory named /efs. To mount
+#### the file system to a different path, modify the MOUNT_DIRECTORY value in the "option_settings"
+#### section.
+####
+#### The FILE_SYSTEM_ID setting references a resource named "FileSystem", which is created by the
+#### storage-efs-createfilesystem.config configuration file. To use this file to mount a
+#### file system that you created outside of AWS Elastic Beanstalk, replace the Ref with the
+#### resource ID (e.g., fs-e7605f4e):
+####
+####      FILE_SYSTEM_ID: fs-e7605f4e
+####
+#### If your environment and file system are in a custom VPC, you must configure the VPC to allow
+#### DNS resolution and DNS host names. See this topic in the VPC User Guide for more information:
+####    http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-dns.html
+###################################################################################################
+
+option_settings:
+  aws:elasticbeanstalk:application:environment:
+    FILE_SYSTEM_ID: '`{"Ref" : "FileSystem"}`'
+    MOUNT_DIRECTORY: '/efs'
+
+##############################################
+#### Do not modify values below this line ####
+##############################################
+    REGION: '`{"Ref": "AWS::Region"}`'
+
+packages:
+  yum:
+    nfs-utils: []
+
+commands:
+  01_mount:
+    command: "/tmp/mount-efs.sh"
+
+files:
+  "/tmp/mount-efs.sh":
+      mode: "000755"
+      content : |
+        #!/bin/bash
+
+        EFS_REGION=$(/opt/elasticbeanstalk/bin/get-config environment -k REGION)
+        EFS_MOUNT_DIR=$(/opt/elasticbeanstalk/bin/get-config environment -k MOUNT_DIRECTORY)
+        EFS_FILE_SYSTEM_ID=$(/opt/elasticbeanstalk/bin/get-config environment -k FILE_SYSTEM_ID)
+
+        echo "Mounting EFS filesystem ${EFS_DNS_NAME} to directory ${EFS_MOUNT_DIR} ..."
+
+        echo 'Stopping NFS ID Mapper...'
+        service rpcidmapd status &> /dev/null
+        if [ $? -ne 0 ] ; then
+            echo 'rpc.idmapd is already stopped!'
+        else
+            service rpcidmapd stop
+            if [ $? -ne 0 ] ; then
+                echo 'ERROR: Failed to stop NFS ID Mapper!'
+                exit 1
+            fi
+        fi
+
+        echo 'Checking if EFS mount directory exists...'
+        if [ ! -d ${EFS_MOUNT_DIR} ]; then
+            echo "Creating directory ${EFS_MOUNT_DIR} ..."
+            mkdir -p ${EFS_MOUNT_DIR}
+            if [ $? -ne 0 ]; then
+                echo 'ERROR: Directory creation failed!'
+                exit 1
+            fi
+        else
+            echo "Directory ${EFS_MOUNT_DIR} already exists!"
+        fi
+
+        mountpoint -q ${EFS_MOUNT_DIR}
+        if [ $? -ne 0 ]; then
+            echo "mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 ${EFS_FILE_SYSTEM_ID}.efs.${EFS_REGION}.amazonaws.com:/ ${EFS_MOUNT_DIR}"
+            mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 ${EFS_FILE_SYSTEM_ID}.efs.${EFS_REGION}.amazonaws.com:/ ${EFS_MOUNT_DIR}
+            if [ $? -ne 0 ] ; then
+                echo 'ERROR: Mount command failed!'
+                exit 1
+            fi
+            chmod 777 ${EFS_MOUNT_DIR}
+            runuser -l  ec2-user -c "touch ${EFS_MOUNT_DIR}/it_works"
+            if [[ $? -ne 0 ]]; then
+                echo 'ERROR: Permission Error!'
+                exit 1
+            else
+                runuser -l  ec2-user -c "rm -f ${EFS_MOUNT_DIR}/it_works"
+            fi
+        else
+            echo "Directory ${EFS_MOUNT_DIR} is already a valid mountpoint!"
+        fi
+
+        echo 'EFS mount complete.'
+

--- a/.ebextensions/tiles.config
+++ b/.ebextensions/tiles.config
@@ -2,4 +2,4 @@
 
 container_commands:
   00_get_earth_tiles:
-    command: "/var/app/current/scripts/get-earth-tiles.sh"
+    command: "scripts/get-earth-tiles.sh"

--- a/.ebextensions/tiles.config
+++ b/.ebextensions/tiles.config
@@ -1,21 +1,5 @@
 #Download mbtiles
 
-files:
-  "/tmp/get-earth-tiles.sh":
-    mode: "00755"
-    owner: root
-    group: root
-    content: |
-      #!/usr/bin/env bash
-      DIR=/var/app/current/docker/data/tiles
-      # docker/data/tiles is shared volume with api component
-      mkdir -p $DIR
-      cd $DIR || exit 1
-      rm latest.planet.mbtiles.gz
-      wget https://s3.amazonaws.com/mapbox/osm-qa-tiles-production/latest.planet.mbtiles.gz
-      gunzip -v latest.planet.mbtiles.gz
-      mv latest.planet.mbtiles tiles.mbtiles
-
 commands:
   00_get_earth_tiles:
-    command: "/tmp/get-earth-tiles.sh"
+    command: "/var/app/current/scripts/get-earth-tiles.sh"

--- a/.ebextensions/tiles.config
+++ b/.ebextensions/tiles.config
@@ -1,4 +1,21 @@
 #Download mbtiles
-container_commands:
+
+files:
+  "/tmp/get-earth-tiles.sh":
+    mode: "00755"
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+      # docker/data/tiles is shared volume with api component
+      mkdir -p "$DIR"/../docker/data/tiles
+      cd "$DIR"/../docker/data/tiles || exit 1
+      rm latest.planet.mbtiles.gz
+      wget https://s3.amazonaws.com/mapbox/osm-qa-tiles-production/latest.planet.mbtiles.gz
+      gunzip latest.planet.mbtiles.gz
+      mv latest.planet.mbtiles tiles.mbtiles
+
+commands:
   00_get_earth_tiles:
-    command: scripts/get-earth-tiles.sh
+    command: "/tmp/get-earth-tiles.sh"

--- a/.ebextensions/tiles.config
+++ b/.ebextensions/tiles.config
@@ -7,13 +7,13 @@ files:
     group: root
     content: |
       #!/usr/bin/env bash
-      DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+      DIR=/var/app/current/docker/data/tiles
       # docker/data/tiles is shared volume with api component
-      mkdir -p "$DIR"/../docker/data/tiles
-      cd "$DIR"/../docker/data/tiles || exit 1
+      mkdir -p $DIR
+      cd $DIR || exit 1
       rm latest.planet.mbtiles.gz
       wget https://s3.amazonaws.com/mapbox/osm-qa-tiles-production/latest.planet.mbtiles.gz
-      gunzip latest.planet.mbtiles.gz
+      gunzip -v latest.planet.mbtiles.gz
       mv latest.planet.mbtiles tiles.mbtiles
 
 commands:

--- a/.ebextensions/tiles.config
+++ b/.ebextensions/tiles.config
@@ -1,0 +1,4 @@
+#Download mbtiles
+container_commands:
+  00_get_earth_tiles:
+    command: scripts/get-earth-tiles.sh

--- a/.ebextensions/tiles.config
+++ b/.ebextensions/tiles.config
@@ -1,5 +1,5 @@
 #Download mbtiles
 
-commands:
+container_commands:
   00_get_earth_tiles:
     command: "/var/app/current/scripts/get-earth-tiles.sh"

--- a/.ebignore
+++ b/.ebignore
@@ -1,0 +1,4 @@
+docker/data/capture/
+docker/data/db/
+docker/data/rabbitmq/
+docker/data/tiles/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ docker/data/
 # env
 .env
 .envrc
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -102,7 +102,7 @@
           "value": "render_queue"
         }
       ],
-      "links": ["rabbitmq:rabbitmq", "api:api"],
+      "links": ["rabbitmq:rabbitmq"],
       "mountPoints": [
         {
           "sourceVolume": "server",

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -37,7 +37,7 @@
       "name": "tile-processor",
       "image": "quay.io/hotosm/hot-mapping-vis-tile-processor-develop:latest",
       "essential": true,
-      "memory": 256,
+      "memory": 512,
       "environment": [
         {
           "name": "GENERATE_UNDERZOOM",
@@ -55,7 +55,7 @@
       "name": "server",
       "image": "quay.io/hotosm/hot-mapping-vis-server-develop:latest",
       "essential": true,
-      "memory": 256,
+      "memory": 512,
       "portMappings": [
         {
           "hostPort": 80,
@@ -78,7 +78,7 @@
       "name": "frontend",
       "image": "quay.io/hotosm/hot-mapping-vis-frontend-develop:latest",
       "essential": true,
-      "memory": 256,
+      "memory": 512,
       "environment": [
         {
           "name": "NODE_ENV",
@@ -90,7 +90,7 @@
       "name": "renderer",
       "image": "quay.io/hotosm/hot-mapping-vis-renderer-develop:latest",
       "essential": true,
-      "memory": 256,
+      "memory": 2048,
       "cpu": 512,
       "environment": [
         {
@@ -114,7 +114,7 @@
       "name": "api",
       "image": "quay.io/hotosm/hot-mapping-vis-api-develop:latest",
       "essential": true,
-      "memory": 256,
+      "memory": 512,
       "environment": [
         {
           "name": "NODE_ENV",
@@ -141,7 +141,7 @@
       "name": "db",
       "image": "postgres",
       "essential": true,
-      "memory": 256,
+      "memory": 512,
       "mountPoints": [
         {
           "sourceVolume": "db",
@@ -157,7 +157,7 @@
       "name": "rabbitmq",
       "image": "rabbitmq:3",
       "essential": true,
-      "memory": 256,
+      "memory": 512,
       "mountPoints": [
         {
           "sourceVolume": "rabbitmq",

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -37,7 +37,7 @@
       "name": "tile-processor",
       "image": "quay.io/hotosm/hot-mapping-vis-tile-processor-develop:latest",
       "essential": true,
-      "memory": 512,
+      "memory": 256,
       "environment": [
         {
           "name": "GENERATE_UNDERZOOM",
@@ -55,7 +55,7 @@
       "name": "server",
       "image": "quay.io/hotosm/hot-mapping-vis-server-develop:latest",
       "essential": true,
-      "memory": 512,
+      "memory": 256,
       "portMappings": [
         {
           "hostPort": 80,
@@ -78,7 +78,7 @@
       "name": "frontend",
       "image": "quay.io/hotosm/hot-mapping-vis-frontend-develop:latest",
       "essential": true,
-      "memory": 512,
+      "memory": 256,
       "environment": [
         {
           "name": "NODE_ENV",
@@ -90,7 +90,7 @@
       "name": "renderer",
       "image": "quay.io/hotosm/hot-mapping-vis-renderer-develop:latest",
       "essential": true,
-      "memory": 2048,
+      "memory": 4096,
       "cpu": 512,
       "environment": [
         {
@@ -114,7 +114,7 @@
       "name": "api",
       "image": "quay.io/hotosm/hot-mapping-vis-api-develop:latest",
       "essential": true,
-      "memory": 512,
+      "memory": 256,
       "environment": [
         {
           "name": "NODE_ENV",
@@ -141,7 +141,7 @@
       "name": "db",
       "image": "postgres",
       "essential": true,
-      "memory": 512,
+      "memory": 256,
       "mountPoints": [
         {
           "sourceVolume": "db",
@@ -157,7 +157,7 @@
       "name": "rabbitmq",
       "image": "rabbitmq:3",
       "essential": true,
-      "memory": 512,
+      "memory": 256,
       "mountPoints": [
         {
           "sourceVolume": "rabbitmq",

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -102,7 +102,7 @@
           "value": "render_queue"
         }
       ],
-      "links": ["rabbitmq:rabbitmq"],
+      "links": ["rabbitmq:rabbitmq", "api"],
       "mountPoints": [
         {
           "sourceVolume": "server",

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -91,6 +91,7 @@
       "image": "quay.io/hotosm/hot-mapping-vis-renderer-develop:latest",
       "essential": true,
       "memory": 256,
+      "cpu": 512,
       "environment": [
         {
           "name": "NODE_ENV",

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -79,7 +79,6 @@
       "image": "quay.io/hotosm/hot-mapping-vis-frontend-develop:latest",
       "essential": true,
       "memory": 256,
-      "links": ["api"],
       "environment": [
         {
           "name": "NODE_ENV",

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,0 +1,168 @@
+{
+  "AWSEBDockerrunVersion": 2,
+  "volumes": [
+    {
+      "name": "tiles",
+      "host": {
+        "sourcePath": "/var/app/current/docker/data/tiles"
+      }
+    },
+    {
+      "name": "server",
+      "host": {
+        "sourcePath": "/var/app/current/docker/data/capture"
+      }
+    },
+    {
+      "name": "db",
+      "host": {
+        "sourcePath": "/var/app/current/docker/data/db"
+      }
+    },
+    {
+      "name": "initsh",
+      "host": {
+        "sourcePath": "/var/app/current/db/init.sh"
+      }
+    },
+    {
+      "name": "rabbitmq",
+      "host": {
+        "sourcePath": "/var/app/current/docker/data/rabbitmq"
+      }
+    }
+  ],
+  "containerDefinitions": [
+    {
+      "name": "tile-processor",
+      "image": "quay.io/hotosm/hot-mapping-vis-tile-processor:latest",
+      "essential": true,
+      "memory": 256,
+      "environment": [
+        {
+          "name": "GENERATE_UNDERZOOM",
+          "value": "0"
+        }
+      ],
+      "mountPoints": [
+        {
+          "sourceVolume": "tiles",
+          "containerPath": "/data/tiles"
+        }
+      ]
+    },
+    {
+      "name": "server",
+      "image": "quay.io/hotosm/hot-mapping-vis-server:latest",
+      "essential": true,
+      "memory": 256,
+      "portMappings": [
+        {
+          "hostPort": 80,
+          "containerPort": 80
+        },
+        {
+          "hostPort": 8080,
+          "containerPort": 80
+        }
+      ],
+      "links": ["api", "frontend"],
+      "mountPoints": [
+        {
+          "sourceVolume": "server",
+          "containerPath": "/data/capture"
+        }
+      ]
+    },
+    {
+      "name": "frontend",
+      "image": "quay.io/hotosm/hot-mapping-vis-frontend-prod:latest",
+      "essential": true,
+      "memory": 256,
+      "environment": [
+        {
+          "name": "NODE_ENV",
+          "value": "production"
+        }
+      ]
+    },
+    {
+      "name": "renderer",
+      "image": "quay.io/hotosm/hot-mapping-vis-renderer-prod:latest",
+      "essential": true,
+      "memory": 256,
+      "environment": [
+        {
+          "name": "NODE_ENV",
+          "value": "production"
+        },
+        {
+          "name": "RENDER_QUEUE",
+          "value": "render_queue"
+        }
+      ],
+      "links": ["rabbitmq"],
+      "mountPoints": [
+        {
+          "sourceVolume": "server",
+          "containerPath": "/data/capture"
+        }
+      ]
+    },
+    {
+      "name": "api",
+      "image": "quay.io/hotosm/hot-mapping-vis-api-prod:latest",
+      "essential": true,
+      "memory": 256,
+      "environment": [
+        {
+          "name": "NODE_ENV",
+          "value": "production"
+        },
+        {
+          "name": "RENDER_QUEUE",
+          "value": "render_queue"
+        },
+        {
+          "name": "MAILGUN_FROM",
+          "value": "visualize@hotosmmail.org"
+        }
+      ],
+      "links": ["db", "rabbitmq"],
+      "mountPoints": [
+        {
+          "sourceVolume": "tiles",
+          "containerPath": "/data/tiles"
+        }
+      ]
+    },
+    {
+      "name": "db",
+      "image": "postgres",
+      "essential": true,
+      "memory": 256,
+      "mountPoints": [
+        {
+          "sourceVolume": "db",
+          "containerPath": "/var/lib/postgresql/data"
+        },
+        {
+          "sourceVolume": "initsh",
+          "containerPath": "/docker-entrypoint-initdb.d/init.sh"
+        }
+      ]
+    },
+    {
+      "name": "rabbitmq",
+      "image": "rabbitmq:3",
+      "essential": true,
+      "memory": 256,
+      "mountPoints": [
+        {
+          "sourceVolume": "rabbitmq",
+          "containerPath": "/var/lib/rabbitmq"
+        }
+      ]
+    }
+  ]
+}

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -79,6 +79,7 @@
       "image": "quay.io/hotosm/hot-mapping-vis-frontend-develop:latest",
       "essential": true,
       "memory": 256,
+      "links": ["api"],
       "environment": [
         {
           "name": "NODE_ENV",

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -22,7 +22,7 @@
     {
       "name": "initsh",
       "host": {
-        "sourcePath": "/var/app/current/db/init.sh"
+        "sourcePath": "/var/app/current/db/init.sql"
       }
     },
     {
@@ -148,7 +148,7 @@
         },
         {
           "sourceVolume": "initsh",
-          "containerPath": "/docker-entrypoint-initdb.d/init.sh"
+          "containerPath": "/docker-entrypoint-initdb.d/init.sql"
         }
       ]
     },

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -4,19 +4,19 @@
     {
       "name": "tiles",
       "host": {
-        "sourcePath": "/var/app/current/docker/data/tiles"
+        "sourcePath": "/efs/data/tiles"
       }
     },
     {
       "name": "server",
       "host": {
-        "sourcePath": "/var/app/current/docker/data/capture"
+        "sourcePath": "/efs/data/capture"
       }
     },
     {
       "name": "db",
       "host": {
-        "sourcePath": "/var/app/current/docker/data/db"
+        "sourcePath": "/efs/data/db"
       }
     },
     {
@@ -28,7 +28,7 @@
     {
       "name": "rabbitmq",
       "host": {
-        "sourcePath": "/var/app/current/docker/data/rabbitmq"
+        "sourcePath": "/efs/data/rabbitmq"
       }
     }
   ],

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -102,7 +102,7 @@
           "value": "render_queue"
         }
       ],
-      "links": ["rabbitmq:rabbitmq"],
+      "links": ["rabbitmq:rabbitmq", "api:api"],
       "mountPoints": [
         {
           "sourceVolume": "server",

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -35,7 +35,7 @@
   "containerDefinitions": [
     {
       "name": "tile-processor",
-      "image": "quay.io/hotosm/hot-mapping-vis-tile-processor:latest",
+      "image": "quay.io/hotosm/hot-mapping-vis-tile-processor-develop:latest",
       "essential": true,
       "memory": 256,
       "environment": [
@@ -53,7 +53,7 @@
     },
     {
       "name": "server",
-      "image": "quay.io/hotosm/hot-mapping-vis-server:latest",
+      "image": "quay.io/hotosm/hot-mapping-vis-server-develop:latest",
       "essential": true,
       "memory": 256,
       "portMappings": [
@@ -76,7 +76,7 @@
     },
     {
       "name": "frontend",
-      "image": "quay.io/hotosm/hot-mapping-vis-frontend-prod:latest",
+      "image": "quay.io/hotosm/hot-mapping-vis-frontend-develop:latest",
       "essential": true,
       "memory": 256,
       "environment": [
@@ -88,7 +88,7 @@
     },
     {
       "name": "renderer",
-      "image": "quay.io/hotosm/hot-mapping-vis-renderer-prod:latest",
+      "image": "quay.io/hotosm/hot-mapping-vis-renderer-develop:latest",
       "essential": true,
       "memory": 256,
       "environment": [
@@ -111,7 +111,7 @@
     },
     {
       "name": "api",
-      "image": "quay.io/hotosm/hot-mapping-vis-api-prod:latest",
+      "image": "quay.io/hotosm/hot-mapping-vis-api-develop:latest",
       "essential": true,
       "memory": 256,
       "environment": [

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -66,7 +66,7 @@
           "containerPort": 80
         }
       ],
-      "links": ["api", "frontend"],
+      "links": ["api:api", "frontend:frontend"],
       "mountPoints": [
         {
           "sourceVolume": "server",
@@ -101,7 +101,7 @@
           "value": "render_queue"
         }
       ],
-      "links": ["rabbitmq"],
+      "links": ["rabbitmq:rabbitmq"],
       "mountPoints": [
         {
           "sourceVolume": "server",
@@ -128,7 +128,7 @@
           "value": "visualize@hotosmmail.org"
         }
       ],
-      "links": ["db", "rabbitmq"],
+      "links": ["db:db", "rabbitmq:rabbitmq"],
       "mountPoints": [
         {
           "sourceVolume": "tiles",

--- a/api/routes.js
+++ b/api/routes.js
@@ -165,15 +165,15 @@ module.exports = ({ channel, db }, callback) => {
         {
           from: process.env.MAILGUN_FROM,
           to: replyContent.email,
-          subject: "Your Visualize Change export is ready",
+          subject: "HOT Mapping Vis Render",
           text: `
             Hi,
 
-            Your visualization export is ready. Please follow this link to download your file: ${SERVER_DOMAIN}/renders/${replyContent.dir}/render.${replyContent.format}.
+            your render is ready at:
 
-            Thank you for using the HOT Visualize Change tool!
+            ${SERVER_DOMAIN}/renders/${replyContent.dir}/render.${replyContent.format}
 
-            Humanitarian OpenStreetMap Team
+            Cheers!
           `
         },
         (err, res) => {

--- a/api/routes.js
+++ b/api/routes.js
@@ -129,6 +129,7 @@ const initRoutes = ({ queueRender, exportsAdd, exportsGetById, exportsUpdate }, 
       mbtiles.getTile(z, x, y, (err, data, headers) => {
         if (err) {
           res.status(404);
+          res.send(err.message);
           res.end();
         } else {
           res.writeHead(200, Object.assign(headers, { "Cache-Control": "private, max-age=3600" }));

--- a/api/routes.js
+++ b/api/routes.js
@@ -165,15 +165,15 @@ module.exports = ({ channel, db }, callback) => {
         {
           from: process.env.MAILGUN_FROM,
           to: replyContent.email,
-          subject: "HOT Mapping Vis Render",
+          subject: "Your Visualize Change export is ready",
           text: `
             Hi,
 
-            your render is ready at:
+            Your visualization export is ready. Please follow this link to download your file: ${SERVER_DOMAIN}/renders/${replyContent.dir}/render.${replyContent.format}.
 
-            ${SERVER_DOMAIN}/renders/${replyContent.dir}/render.${replyContent.format}
+            Thank you for using the HOT Visualize Change tool!
 
-            Cheers!
+            Humanitarian OpenStreetMap Team
           `
         },
         (err, res) => {

--- a/api/routes.js
+++ b/api/routes.js
@@ -165,15 +165,14 @@ module.exports = ({ channel, db }, callback) => {
         {
           from: process.env.MAILGUN_FROM,
           to: replyContent.email,
-          subject: "HOT Mapping Vis Render",
+          subject: "Your Visualize Change export is ready",
           text: `
             Hi,
 
-            your render is ready at:
+            Your visualization export is ready. Please follow this link to download your file: 
+            ${SERVER_DOMAIN}/renders/${replyContent.dir}/render.${replyContent.format}.
 
-            ${SERVER_DOMAIN}/renders/${replyContent.dir}/render.${replyContent.format}
-
-            Cheers!
+            Humanitarian OpenStreetMap Team
           `
         },
         (err, res) => {

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS exports (
+  id SERIAL,
+  parent_id integer,
+  config jsonb NOT NULL
+);

--- a/docker/renderer/Dockerfile.dev
+++ b/docker/renderer/Dockerfile.dev
@@ -3,7 +3,7 @@ FROM node:carbon-stretch
 WORKDIR /app
 
 RUN apt-get update
-RUN apt-get install -y xvfb ffmpeg libgconf-2-4 libnss3
+RUN apt-get install -y xvfb ffmpeg libgconf-2-4 libnss3 libgtk-3-0 libgtk-3-dev
 
 RUN yarn global add wait-on
 

--- a/docker/renderer/Dockerfile.prod
+++ b/docker/renderer/Dockerfile.prod
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY renderer .
 
 RUN apt-get update
-RUN apt-get install -y xvfb ffmpeg libgconf-2-4 libnss3
+RUN apt-get install -y xvfb ffmpeg libgconf-2-4 libnss3 libgtk-3-0 libgtk-3-dev
 
 # info on ARG/ENV and build step: https://github.com/docker/compose/issues/1837
 ARG NODE_ENV

--- a/docker/tile-processor/Dockerfile.prod
+++ b/docker/tile-processor/Dockerfile.prod
@@ -25,5 +25,5 @@ RUN crontab -l
 WORKDIR /app
 COPY tile-processor/get-and-process-tiles.sh .
 
-CMD rsyslogd && cron && tail -F /var/log/cron.log /var/log/syslog
+CMD rsyslogd -n && cron && tail -F /var/log/cron.log /var/log/syslog
 

--- a/frontend/src/constans/index.js
+++ b/frontend/src/constans/index.js
@@ -151,7 +151,7 @@ module.exports = {
   TOPBAR_TITLE: "Visualize Change",
 
   DEFAULT_DATE_FORMAT: "YYYY-MM-DD",
-  MAX_ANIMATION_UNITS: 60,
+  MAX_ANIMATION_UNITS: 90,
   INTERVAL_VALUES,
   PAGE_TITLE: "HOT Visualize Change",
   TOPBAR_TITLE: "Visualize Change",

--- a/frontend/src/constans/index.js
+++ b/frontend/src/constans/index.js
@@ -151,7 +151,7 @@ module.exports = {
   TOPBAR_TITLE: "Visualize Change",
 
   DEFAULT_DATE_FORMAT: "YYYY-MM-DD",
-  MAX_ANIMATION_UNITS: 30,
+  MAX_ANIMATION_UNITS: 60,
   INTERVAL_VALUES,
   PAGE_TITLE: "HOT Visualize Change",
   TOPBAR_TITLE: "Visualize Change",

--- a/frontend/src/constans/index.js
+++ b/frontend/src/constans/index.js
@@ -151,7 +151,7 @@ module.exports = {
   TOPBAR_TITLE: "Visualize Change",
 
   DEFAULT_DATE_FORMAT: "YYYY-MM-DD",
-  MAX_ANIMATION_UNITS: 60,
+  MAX_ANIMATION_UNITS: 30,
   INTERVAL_VALUES,
   PAGE_TITLE: "HOT Visualize Change",
   TOPBAR_TITLE: "Visualize Change",

--- a/renderer/electron.js
+++ b/renderer/electron.js
@@ -7,6 +7,8 @@ const { app, BrowserWindow, ipcMain } = require("electron");
 const logger = require("./logger");
 const { getCaptureDir, RENDERING_SHOT, RENDERING_DONE, RENDERER_TIMEOUT } = require("./common");
 
+const LOCAL_DEBUG = process.env.LOCAL_DEBUG;
+
 if (!process.argv[2]) {
   logger.info("pass stringified JSON data for rendering");
   process.exit(1);
@@ -67,9 +69,11 @@ const convertToVideo = callback => {
 let mainWindow;
 
 app.on("ready", () => {
-  // hide window if we are not debugging
-  const show = process.env.LOCAL_DEBUG ? true : false;
-  mainWindow = new BrowserWindow({ show });
+  // hide window if we are not debugging, and set some web preferences as needed
+  const show = LOCAL_DEBUG ? true : false;
+  const webPreferences = LOCAL_DEBUG ? {} : { webgl: true, offscreen: true };
+
+  mainWindow = new BrowserWindow({ show, webPreferences });
 
   mainWindow.setContentSize(width, height);
   mainWindow.setResizable(false);
@@ -116,6 +120,7 @@ setInterval(() => {
 
   if (time > RENDERER_TIMEOUT) {
     logger.error("renderer timeouted, exiting...");
+    app.quit();
     process.exit(1);
   }
 }, 1000);

--- a/renderer/package.json
+++ b/renderer/package.json
@@ -18,7 +18,7 @@
     "electron": "^1.7.10",
     "fluent-ffmpeg": "^2.1.2",
     "left-pad": "^1.2.0",
-    "mapbox-gl": "0.43.0",
+    "mapbox-gl": "0.46.0",
     "moment": "^2.20.1",
     "winston": "^3.0.0-rc1"
   },

--- a/renderer/package.json
+++ b/renderer/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "amqplib": "^0.5.2",
-    "electron": "^1.7.10",
+    "electron": "^2.0.5",
     "fluent-ffmpeg": "^2.1.2",
     "left-pad": "^1.2.0",
     "mapbox-gl": "0.46.0",

--- a/renderer/package.json
+++ b/renderer/package.json
@@ -18,7 +18,7 @@
     "electron": "^1.7.10",
     "fluent-ffmpeg": "^2.1.2",
     "left-pad": "^1.2.0",
-    "mapbox-gl": "0.46.0",
+    "mapbox-gl": "0.43.0",
     "moment": "^2.20.1",
     "winston": "^3.0.0-rc1"
   },

--- a/renderer/scripts/run-electron
+++ b/renderer/scripts/run-electron
@@ -3,4 +3,4 @@
 # gpu: https://medium.com/social-tables-tech/how-we-test-webgl-on-continuous-integration-37a1ead55fd7
 # $1 is rendering config json string that electron assumes is first argument
 
-./node_modules/.bin/electron electron.js "$1" --ignore-gpu-blacklist
+./node_modules/.bin/electron electron.js "$1" --ignore-gpu-blacklist --enable-logging

--- a/renderer/yarn.lock
+++ b/renderer/yarn.lock
@@ -42,9 +42,9 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.0.0.tgz#c1de4293081424da3ac30c23afa850af1019bb54"
 
-"@types/node@^7.0.18":
-  version "7.0.52"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.52.tgz#8990d3350375542b0c21a83cd0331e6a8fc86716"
+"@types/node@^8.0.24":
+  version "8.10.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.21.tgz#12b3f2359b27aa05a45d886c8ba1eb8d1a77e285"
 
 "JSV@>= 4.0.x":
   version "4.0.2"
@@ -238,9 +238,13 @@ aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
 
-aws4@^1.2.1, aws4@^1.6.0:
+aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
+
+aws4@^1.6.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
 babylon@^6.15.0:
   version "6.18.0"
@@ -293,18 +297,6 @@ boom@2.x.x:
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
   dependencies:
     hoek "2.x.x"
-
-boom@4.x.x:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
-  dependencies:
-    hoek "4.x.x"
-
-boom@5.x.x:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
-  dependencies:
-    hoek "4.x.x"
 
 boxen@^1.2.1:
   version "1.3.0"
@@ -376,6 +368,10 @@ bubleify@^0.7.0:
 buffer-equal@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-0.0.1.tgz#91bc74b11ea405bc916bc6aa908faafa5b4aac4b"
+
+buffer-from@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
 
 buffer-more-ints@0.0.2:
   version "0.0.2"
@@ -561,6 +557,12 @@ colorspace@1.0.x:
     color "0.8.x"
     text-hex "0.0.x"
 
+combined-stream@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  dependencies:
+    delayed-stream "~1.0.0"
+
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
@@ -579,7 +581,16 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.6.0, concat-stream@~1.6.0:
+concat-stream@1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
+concat-stream@~1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -651,12 +662,6 @@ cryptiles@2.x.x:
   dependencies:
     boom "2.x.x"
 
-cryptiles@3.x.x:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
-  dependencies:
-    boom "5.x.x"
-
 crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
@@ -704,6 +709,10 @@ decode-uri-component@^0.2.0:
 deep-equal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
 
 deep-extend@~0.4.0:
   version "0.4.2"
@@ -789,11 +798,11 @@ electron-download@^3.0.1:
     semver "^5.3.0"
     sumchecker "^1.2.0"
 
-electron@^1.7.10:
-  version "1.7.10"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.10.tgz#3a3e83d965fd7fafe473be8ddf8f472561b6253d"
+electron@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.5.tgz#6045db011e2547062a36e8c5da84d4982f434fc0"
   dependencies:
-    "@types/node" "^7.0.18"
+    "@types/node" "^8.0.24"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 
@@ -808,14 +817,14 @@ env-variable@0.0.x:
   resolved "https://registry.yarnpkg.com/env-variable/-/env-variable-0.0.3.tgz#b86c1641be5610267d506f18071ea76d707097cb"
 
 error-ex@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   dependencies:
     is-arrayish "^0.2.1"
 
 es6-promise@^4.0.5:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.2.tgz#f722d7769af88bd33bc13ec6605e1f92966b82d9"
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
 
 escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -946,9 +955,13 @@ extend-shallow@^3.0.0:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.0, extend@~3.0.1:
+extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
+
+extend@~3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
 extglob@^2.0.2:
   version "2.0.4"
@@ -964,12 +977,12 @@ extglob@^2.0.2:
     to-regex "^3.0.1"
 
 extract-zip@^1.0.3:
-  version "1.6.6"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.6.tgz#1290ede8d20d0872b429fd3f351ca128ec5ef85c"
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.7.tgz#a840b4b8af6403264c8db57f4f1a74333ef81fe9"
   dependencies:
-    concat-stream "1.6.0"
+    concat-stream "1.6.2"
     debug "2.6.9"
-    mkdirp "0.5.0"
+    mkdirp "0.5.1"
     yauzl "2.4.1"
 
 extsprintf@1.3.0:
@@ -990,8 +1003,8 @@ falafel@^2.1.0:
     object-keys "^1.0.6"
 
 fast-deep-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -1062,11 +1075,11 @@ form-data@~2.1.1:
     mime-types "^2.1.12"
 
 form-data@~2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
   dependencies:
     asynckit "^0.4.0"
-    combined-stream "^1.0.5"
+    combined-stream "1.0.6"
     mime-types "^2.1.12"
 
 fragment-cache@^0.2.1:
@@ -1314,30 +1327,17 @@ hawk@3.1.3, hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-hawk@~6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
-  dependencies:
-    boom "4.x.x"
-    cryptiles "3.x.x"
-    hoek "4.x.x"
-    sntp "2.x.x"
-
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoek@4.x.x:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
-
 home-path@^1.0.1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/home-path/-/home-path-1.0.5.tgz#788b29815b12d53bacf575648476e6f9041d133f"
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/home-path/-/home-path-1.0.6.tgz#d549dc2465388a7f8667242c5b31588d29af29fc"
 
 hosted-git-info@^2.1.4:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
 http-signature@~1.1.0:
   version "1.1.1"
@@ -1879,11 +1879,21 @@ mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
-mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.7:
+mime-db@~1.35.0:
+  version "1.35.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
+
+mime-types@^2.1.12, mime-types@~2.1.7:
   version "2.1.17"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:
     mime-db "~1.30.0"
+
+mime-types@~2.1.17:
+  version "2.1.19"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
+  dependencies:
+    mime-db "~1.35.0"
 
 minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
@@ -1910,13 +1920,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
-  dependencies:
-    minimist "0.0.8"
-
-"mkdirp@>=0.5 0", mkdirp@^0.5.1:
+mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -2293,8 +2297,8 @@ qs@~6.4.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
 qs@~6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
 quickselect@^1.0.0:
   version "1.0.1"
@@ -2315,11 +2319,20 @@ quote-stream@~0.0.0:
     minimist "0.0.8"
     through2 "~0.4.1"
 
-rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.1.7:
+rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.4.tgz#a0f606caae2a3b862bbd0ef85482c0125b315fa3"
   dependencies:
     deep-extend "~0.4.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
+rc@^1.1.2:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  dependencies:
+    deep-extend "^0.6.0"
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
@@ -2456,8 +2469,8 @@ request@2.81.0:
     uuid "^3.0.0"
 
 request@^2.45.0:
-  version "2.83.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
+  version "2.87.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.6.0"
@@ -2467,7 +2480,6 @@ request@^2.45.0:
     forever-agent "~0.6.1"
     form-data "~2.3.1"
     har-validator "~5.0.3"
-    hawk "~6.0.2"
     http-signature "~1.2.0"
     is-typedarray "~1.0.0"
     isstream "~0.1.2"
@@ -2477,7 +2489,6 @@ request@^2.45.0:
     performance-now "^2.1.0"
     qs "~6.5.1"
     safe-buffer "^5.1.1"
-    stringstream "~0.0.5"
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
@@ -2512,9 +2523,13 @@ rx@2.3.24:
   version "2.3.24"
   resolved "https://registry.yarnpkg.com/rx/-/rx-2.3.24.tgz#14f950a4217d7e35daa71bbcbe58eff68ea4b2b7"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safe-buffer@^5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
 seedrandom@^2.4.2:
   version "2.4.3"
@@ -2636,12 +2651,6 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
-sntp@2.x.x:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
-  dependencies:
-    hoek "4.x.x"
-
 sort-asc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/sort-asc/-/sort-asc-0.1.0.tgz#ab799df61fc73ea0956c79c4b531ed1e9e7727e9"
@@ -2689,19 +2698,27 @@ spawn-command@^0.0.2-1:
   version "0.0.2-1"
   resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
 
-spdx-correct@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
+spdx-correct@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
   dependencies:
-    spdx-license-ids "^1.0.2"
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
 
-spdx-expression-parse@~1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz#9bdf2f20e1f40ed447fbe273266191fced51626c"
+spdx-exceptions@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
 
-spdx-license-ids@^1.0.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
 
 speedometer@~0.1.2:
   version "0.1.4"
@@ -2813,7 +2830,7 @@ string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
-stringstream@~0.0.4, stringstream@~0.0.5:
+stringstream@~0.0.4:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
@@ -2991,9 +3008,15 @@ touch@^3.1.0:
   dependencies:
     nopt "~1.0.10"
 
-tough-cookie@~2.3.0, tough-cookie@~2.3.3:
+tough-cookie@~2.3.0:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
+  dependencies:
+    punycode "^1.4.1"
+
+tough-cookie@~2.3.3:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
   dependencies:
     punycode "^1.4.1"
 
@@ -3135,16 +3158,20 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-uuid@^3.0.0, uuid@^3.1.0:
+uuid@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
+uuid@^3.1.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+
 validate-npm-package-license@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
   dependencies:
-    spdx-correct "~1.0.0"
-    spdx-expression-parse "~1.0.0"
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
 
 verror@1.10.0:
   version "1.10.0"

--- a/scripts/eb-get-earth-tiles.sh
+++ b/scripts/eb-get-earth-tiles.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+cd /efs/data/tiles || exit 1
+rm latest.planet.mbtiles.gz
+wget https://s3.amazonaws.com/mapbox/osm-qa-tiles-production/latest.planet.mbtiles.gz
+gunzip latest.planet.mbtiles.gz
+mv latest.planet.mbtiles tiles.mbtiles

--- a/server/nginx.conf
+++ b/server/nginx.conf
@@ -66,7 +66,7 @@ http {
       proxy_http_version 1.1;
       proxy_set_header   Upgrade $http_upgrade;
       proxy_set_header   Connection 'upgrade';
-      proxy_set_header   Host $host;
+      # proxy_set_header   Host $host;
       proxy_cache_bypass $http_upgrade;
     }
 

--- a/server/nginx.conf
+++ b/server/nginx.conf
@@ -66,8 +66,11 @@ http {
       proxy_http_version 1.1;
       proxy_set_header   Upgrade $http_upgrade;
       proxy_set_header   Connection 'upgrade';
-      # proxy_set_header   Host $host;
+      proxy_set_header   Host $host;
       proxy_cache_bypass $http_upgrade;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-NginX-Proxy true;
     }
 
     location /health-check {


### PR DESCRIPTION
This PR enables CircleCI to build, test*, and deploy the app to AWS Elastic Beanstalk. 

The process is as follows:
1. CircleCI builds the production app in docker-compose
2. It runs the containers and pushes them to the quay.io image repository
3. It runs `eb deploy` which does it's thing
4. If an Elastic File System isn't set up already for the environment, one is set up. This is where the static tiles and exports live so multiple instances can access. 
4. Elastic Beanstalk uses the Elastic Container Service to pull the remote images from quay.io into a container instance (or multiple depending on the load balancer) and connects them in the same way as docker-compose with networking, environment variables, and volumes linked up properly. 

Known issues and hazards:
- Do not set multiple environments to receive updates from the same branch, because quay.io images are not versioned like the app is when deployed. This will break things. 
- Cloning a new EB environment is not a smooth process because of the above issue as well, I think. It's also important to double-check the environment variables are set correctly in both CircleCI and AWS. 

Future tasks:
- Improve the hazards above through docker image tagging
- Move the images to the ECR for everything to be contained in one system

*There are no tests other than running a docker-compose build command and seeing if it runs into errors. 