### PR TITLE
Removed 'Satellite' theme from edit options

### DIFF
--- a/frontend/src/components/sidebar-edit.js
+++ b/frontend/src/components/sidebar-edit.js
@@ -245,7 +245,7 @@ const ThemeSelect = ({ styles, onBackgroundStyleChange, isMapLoaded }) => (
           value={styles.background}
           onChange={ev => onBackgroundStyleChange(ev.target.value)}
         >
-          {["light", "dark", "basic", "streets", "bright", "satellite"].map(style => (
+          {["light", "dark", "basic", "streets", "bright"].map(style => (
             <option key={style} value={style}>
               {capitalizeFirstLetter(style)}
             </option>


### PR DESCRIPTION
Bug was preventing building footprint and road networks being displayed on top of the satellite theme, so this has been removed/disabled until it is fixed